### PR TITLE
 Unregister what was registered. 

### DIFF
--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -109,7 +109,7 @@ void UnregisterProfiles()
 		CComPtr<ITfInputProcessorProfileMgr> pInputProcessorProfileMgr;
 		hr = pInputProcessorProfileMgr.CoCreateInstance(CLSID_TF_InputProcessorProfiles, NULL, CLSCTX_ALL);
 		if (FAILED(hr))
-			return FALSE;
+			return;
 
 		hr = pInputProcessorProfileMgr->UnregisterProfile(
 			c_clsidTextService,

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -176,6 +176,27 @@ void UnregisterCategories()
 		return;
 
 	hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIP_KEYBOARD, c_clsidTextService);
+	if (hr != S_OK)
+		goto UnregisterExit;
+
+	hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_UIELEMENTENABLED, c_clsidTextService);
+	if (hr != S_OK)
+		goto UnregisterExit;
+
+	hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_INPUTMODECOMPARTMENT, c_clsidTextService);
+	if (hr != S_OK)
+		goto UnregisterExit;
+
+	if (IsWindows8OrGreater())
+	{
+		hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_IMMERSIVESUPPORT, c_clsidTextService);
+		if (hr != S_OK)
+			goto UnregisterExit;
+
+		hr = pCategoryMgr->UnregisterCategory(c_clsidTextService, GUID_TFCAT_TIPCAP_SYSTRAYSUPPORT, c_clsidTextService);
+	}
+
+UnregisterExit:
 	pCategoryMgr->Release();
 }
 

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -126,6 +126,10 @@ void UnregisterProfiles()
 
 		pInputProcessProfiles->SubstituteKeyboardLayout(
 			c_clsidTextService, TEXTSERVICE_LANGID, c_guidProfile, NULL);
+		pInputProcessorProfiles->RemoveLanguageProfile(
+			c_clsidTextService,
+			TEXTSERVICE_LANGID,
+			c_guidProfile);
 		pInputProcessProfiles->Unregister(c_clsidTextService);
 		pInputProcessProfiles->Release();
 	}

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -101,7 +101,6 @@ BOOL RegisterProfiles()
 
 void UnregisterProfiles()
 {
-	ITfInputProcessorProfiles *pInputProcessProfiles;
 	HRESULT hr;
 
 	if (IsWindows8OrGreater())
@@ -119,19 +118,20 @@ void UnregisterProfiles()
 	}
 	else
 	{
+		CComPtr<ITfInputProcessorProfiles> pInputProcessorProfiles;
 		hr = CoCreateInstance(CLSID_TF_InputProcessorProfiles, NULL, CLSCTX_INPROC_SERVER,
-			IID_ITfInputProcessorProfiles, (void **)&pInputProcessProfiles);
+			IID_ITfInputProcessorProfiles, (void **)&pInputProcessorProfiles);
 		if (FAILED(hr))
 			return;
 
-		pInputProcessProfiles->SubstituteKeyboardLayout(
+		pInputProcessorProfiles->SubstituteKeyboardLayout(
 			c_clsidTextService, TEXTSERVICE_LANGID, c_guidProfile, NULL);
 		pInputProcessorProfiles->RemoveLanguageProfile(
 			c_clsidTextService,
 			TEXTSERVICE_LANGID,
 			c_guidProfile);
-		pInputProcessProfiles->Unregister(c_clsidTextService);
-		pInputProcessProfiles->Release();
+		pInputProcessorProfiles->Unregister(c_clsidTextService);
+		pInputProcessorProfiles->Release();
 	}
 }
 

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -65,6 +65,8 @@ BOOL RegisterProfiles()
 			0,
 			TRUE,
 			0);
+		if (FAILED(hr))
+			return FALSE;
 	}
 	else
 	{

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -116,8 +116,6 @@ void UnregisterProfiles()
 			TEXTSERVICE_LANGID,
 			c_guidProfile,
 			0);
-		if (FAILED(hr))
-			return FALSE;
 	}
 	else
 	{

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -118,7 +118,7 @@ void UnregisterProfiles()
 	}
 	else
 	{
-		CComPtr<ITfInputProcessorProfiles> pInputProcessorProfiles;
+		ITfInputProcessorProfiles pInputProcessorProfiles;
 		hr = CoCreateInstance(CLSID_TF_InputProcessorProfiles, NULL, CLSCTX_INPROC_SERVER,
 			IID_ITfInputProcessorProfiles, (void **)&pInputProcessorProfiles);
 		if (FAILED(hr))

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -118,7 +118,7 @@ void UnregisterProfiles()
 	}
 	else
 	{
-		ITfInputProcessorProfiles pInputProcessProfiles;
+		ITfInputProcessorProfiles *pInputProcessProfiles;
 		hr = CoCreateInstance(CLSID_TF_InputProcessorProfiles, NULL, CLSCTX_INPROC_SERVER,
 			IID_ITfInputProcessorProfiles, (void **)&pInputProcessProfiles);
 		if (FAILED(hr))

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -106,6 +106,11 @@ void UnregisterProfiles()
 
 	if (IsWindows8OrGreater())
 	{
+		CComPtr<ITfInputProcessorProfileMgr> pInputProcessorProfileMgr;
+		hr = pInputProcessorProfileMgr.CoCreateInstance(CLSID_TF_InputProcessorProfiles, NULL, CLSCTX_ALL);
+		if (FAILED(hr))
+			return FALSE;
+
 		hr = pInputProcessorProfileMgr->UnregisterProfile(
 			c_clsidTextService,
 			TEXTSERVICE_LANGID,

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -104,15 +104,28 @@ void UnregisterProfiles()
 	ITfInputProcessorProfiles *pInputProcessProfiles;
 	HRESULT hr;
 
-	hr = CoCreateInstance(CLSID_TF_InputProcessorProfiles, NULL, CLSCTX_INPROC_SERVER,
-		IID_ITfInputProcessorProfiles, (void **)&pInputProcessProfiles);
-	if (FAILED(hr))
-		return;
+	if (IsWindows8OrGreater())
+	{
+		hr = pInputProcessorProfileMgr->UnregisterProfile(
+			c_clsidTextService,
+			TEXTSERVICE_LANGID,
+			c_guidProfile,
+			0);
+		if (FAILED(hr))
+			return FALSE;
+	}
+	else
+	{
+		hr = CoCreateInstance(CLSID_TF_InputProcessorProfiles, NULL, CLSCTX_INPROC_SERVER,
+			IID_ITfInputProcessorProfiles, (void **)&pInputProcessProfiles);
+		if (FAILED(hr))
+			return;
 
-	pInputProcessProfiles->SubstituteKeyboardLayout(
-		c_clsidTextService, TEXTSERVICE_LANGID, c_guidProfile, NULL);
-	pInputProcessProfiles->Unregister(c_clsidTextService);
-	pInputProcessProfiles->Release();
+		pInputProcessProfiles->SubstituteKeyboardLayout(
+			c_clsidTextService, TEXTSERVICE_LANGID, c_guidProfile, NULL);
+		pInputProcessProfiles->Unregister(c_clsidTextService);
+		pInputProcessProfiles->Release();
+	}
 }
 
 BOOL RegisterCategories()

--- a/WeaselTSF/Register.cpp
+++ b/WeaselTSF/Register.cpp
@@ -118,20 +118,20 @@ void UnregisterProfiles()
 	}
 	else
 	{
-		ITfInputProcessorProfiles pInputProcessorProfiles;
+		ITfInputProcessorProfiles pInputProcessProfiles;
 		hr = CoCreateInstance(CLSID_TF_InputProcessorProfiles, NULL, CLSCTX_INPROC_SERVER,
-			IID_ITfInputProcessorProfiles, (void **)&pInputProcessorProfiles);
+			IID_ITfInputProcessorProfiles, (void **)&pInputProcessProfiles);
 		if (FAILED(hr))
 			return;
 
-		pInputProcessorProfiles->SubstituteKeyboardLayout(
+		pInputProcessProfiles->SubstituteKeyboardLayout(
 			c_clsidTextService, TEXTSERVICE_LANGID, c_guidProfile, NULL);
-		pInputProcessorProfiles->RemoveLanguageProfile(
+		pInputProcessProfiles->RemoveLanguageProfile(
 			c_clsidTextService,
 			TEXTSERVICE_LANGID,
 			c_guidProfile);
-		pInputProcessorProfiles->Unregister(c_clsidTextService);
-		pInputProcessorProfiles->Release();
+		pInputProcessProfiles->Unregister(c_clsidTextService);
+		pInputProcessProfiles->Release();
 	}
 }
 


### PR DESCRIPTION
Kah [rime/weasel#549](https://github.com/rime/weasel/pull/549) kāng-khuán.

因為手動改GUID liáu 程式 siok-tooh，發覺是這段khóo ài 修。

To keep windows reg clean. `UnregisterProfiles()` unregisters all registered in `RegisterProfiles()`

`UnregisterProfiles()` follows the structure of `RegisterProfiles()`, separating win-7 and newer version.

This code are tested by reinstalling twice, in win7 and win10.

